### PR TITLE
Added a .gitattributes file to ignore training/testing text files fro…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+TestFiles/* linguist-vendored
+ExampleFiles/* linguist-vendored
+random-test-data/* linguist-vendored


### PR DESCRIPTION
…m GitHub’s language identifier (I was sick of seeing this showing as a Perl repo instead of a Java repo).

See here for docs: https://github.com/github/linguist#using-gitattributes